### PR TITLE
fixup for JMSMessageConsumerTest

### DIFF
--- a/src/test/java/org/apache/activemq/JMSTestBase.java
+++ b/src/test/java/org/apache/activemq/JMSTestBase.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import static com.google.common.truth.TruthJUnit.assume;
 
 public class JMSTestBase {
-   private static String NETTY_CONNECTOR_FACTORY = NettyConnectorFactory.class.getCanonicalName();;
+   private static String NETTY_CONNECTOR_FACTORY = NettyConnectorFactory.class.getCanonicalName();
 
    @Parameterized.Parameters(name = "protocol={0}")
    public static Collection getParameters() {

--- a/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSMessageConsumerTest.java
+++ b/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSMessageConsumerTest.java
@@ -37,6 +37,7 @@ public class JMSMessageConsumerTest extends JMSClientTestSupport {
    @Test(timeout = 30000)
    public void testSelectorsWithJMSPriority() throws Exception {
       Connection connection = createConnection();
+      connection.start();
 
       try {
          Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
@@ -50,6 +51,8 @@ public class JMSMessageConsumerTest extends JMSClientTestSupport {
          message = session.createTextMessage();
          message.setText("hello + 9");
          p.send(message, DeliveryMode.PERSISTENT, 9, 0);
+
+         Thread.sleep(2000);
 
          QueueBrowser browser = session.createBrowser(queue);
          Enumeration enumeration = browser.getEnumeration();

--- a/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/BodyTest.java
+++ b/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/BodyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.jms.jms2client;
+
+import org.apache.activemq.JMSTestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.jms.*;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+@RunWith(value = Parameterized.class)
+public class BodyTest extends JMSTestBase {
+
+   private static final String Q_NAME = "SomeQueue";
+   private javax.jms.Queue queue;
+
+   @Test
+   public void testBodyConversion() throws Throwable {
+      try (
+         Connection conn = cf.createConnection();
+      ) {
+         Session sess = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         queue = sess.createQueue(Q_NAME);
+         MessageProducer producer = sess.createProducer(queue);
+
+         MessageConsumer cons = sess.createConsumer(queue);
+         conn.start();
+
+         BytesMessage bytesMessage = sess.createBytesMessage();
+         System.out.println("message type is: " + bytesMessage.getJMSType());
+         bytesMessage.getBody(String.class);
+         producer.send(bytesMessage);
+
+         Message msg = cons.receive(500);
+         assertNotNull(msg);
+
+         try {
+            System.out.println("message type is: " + msg.getJMSType());
+            msg.getBody(String.class);
+            fail("Exception expected");
+         } catch (MessageFormatException e) {
+         }
+      }
+
+   }
+}

--- a/src/test/java/org/apache/activemq/artemis/tests/integration/jms/largemessage/JMSLargeMessageTest.java
+++ b/src/test/java/org/apache/activemq/artemis/tests/integration/jms/largemessage/JMSLargeMessageTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.jms.largemessage;
+
+import org.apache.activemq.JMSTestBase;
+import org.apache.activemq.artemis.utils.UUIDGenerator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.jms.*;
+
+@RunWith(value = Parameterized.class)
+public class JMSLargeMessageTest extends JMSTestBase {
+   // Constants -----------------------------------------------------
+
+   // Attributes ----------------------------------------------------
+
+   Queue queue1;
+
+   // Static --------------------------------------------------------
+
+   // Constructors --------------------------------------------------
+
+   // Public --------------------------------------------------------
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+      queue1 = createQueue("queue1");
+   }
+
+   @Test(timeout = 30000)
+   public void testHugeString() throws Exception {
+      int msgSize = 1024 * 1024;
+
+      Connection conn = cf.createConnection();
+
+      Session session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+      MessageProducer prod = session.createProducer(queue1);
+
+      TextMessage m = session.createTextMessage();
+
+      // TODO: this is extra compared to original test, hoping maybe it gives me the JMSException I crave
+      m.setJMSDeliveryMode(DeliveryMode.PERSISTENT);
+
+      StringBuffer buffer = new StringBuffer();
+      while (buffer.length() < msgSize) {
+         buffer.append(UUIDGenerator.getInstance().generateStringUUID());
+      }
+
+      final String originalString = buffer.toString();
+
+      m.setText(originalString);
+
+      buffer = null;
+
+      prod.send(m);
+
+      conn.close();
+
+//      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), 1);
+
+      conn = cf.createConnection();
+
+      session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+      MessageConsumer cons = session.createConsumer(queue1);
+
+      conn.start();
+
+      TextMessage rm = (TextMessage) cons.receive(10000);
+      Assert.assertNotNull(rm);
+
+      String str = rm.getText();
+      Assert.assertEquals(originalString, str);
+      conn.close();
+//      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), 0);
+
+   }
+
+}


### PR DESCRIPTION
the upstream suite starts up the connection, I need to do it myself

terrible situation writing tests that are supposed to fail, one never
knows when they really are supposed to, and when it is fail fail...

The extra sleep is for OpenWire, it may miss a message in browsing